### PR TITLE
Gpg

### DIFF
--- a/unipass
+++ b/unipass
@@ -10,7 +10,7 @@
 #                             Config
 #===============================================================================
 
-GPG_ID=salmanabedin@disroot.org
+GPG_ID=salmanabedin@disroot.org     # GPG_ID can be your ID or even email, attached to the gpg key you want to use
 PASSWORD_PATH=$GIT/own/magpie-private/.local/share/passwords
 DMENU=amenu
 

--- a/unipass
+++ b/unipass
@@ -10,7 +10,7 @@
 #                             Config
 #===============================================================================
 
-GPG_MAIL=salmanabedin@disroot.org
+GPG_ID=salmanabedin@disroot.org
 PASSWORD_PATH=$GIT/own/magpie-private/.local/share/passwords
 DMENU=amenu
 
@@ -33,7 +33,7 @@ case $1 in
       fi
       FILE=$PASSWORD_PATH/"$ACCOUNT"
       echo "$NAME,$PASS" > "$FILE"
-      gpg -esr $GPG_MAIL "$FILE"
+      gpg -esr $GPG_ID "$FILE"
       rm "$FILE"
       ;;
    f*)


### PR DESCRIPTION
Since GPG keys may or may not have email attached to them, but they always have name/ID attached them, using ID would be more universal/widely used. 